### PR TITLE
BF: Fix `getDeviceProfile` so it no longer returns unusable keys

### DIFF
--- a/psychopy_cedrus/base.py
+++ b/psychopy_cedrus/base.py
@@ -291,8 +291,8 @@ class BaseXidPhotodiodeGroup(BasePhotodiodeGroup):
             return
         # store value
         self._threshold = threshold
-        # convert from base 16
-        thr = threshold / 255 * 100
+        # convert from base 16 integer to ASCII character
+        thr = chr(int(threshold / 255 * 100))
         # get channel selector
         selector = self.selectors[channel]
         # send command
@@ -496,8 +496,8 @@ class BaseXidVoiceKeyGroup(BaseVoiceKeyGroup):
             return
         # store value
         self._threshold = threshold
-        # convert from base 16
-        thr = int(threshold / 255 * 100)
+        # convert from base 16 integer to ASCII character
+        thr = chr(int(threshold / 255 * 100))
         # send command
         self.parent.xid.con.send_xid_command(f"itM{thr}")
         # dispatch

--- a/psychopy_cedrus/base.py
+++ b/psychopy_cedrus/base.py
@@ -268,6 +268,7 @@ class BaseXidPhotodiodeGroup(BasePhotodiodeGroup):
             other = other.parent
         elif isinstance(other, dict) and "pad" in other:
             # if given a dict, make sure we have an `index` rather than a `pad`
+            other = other.copy()
             other['index'] = other.pop('pad')
         # use parent's comparison method
         return self.parent.isSameDevice(other)
@@ -392,6 +393,7 @@ class BaseXidButtonGroup(BaseButtonGroup):
             other = other.parent
         elif isinstance(other, dict) and "pad" in other:
             # if given a dict, make sure we have an `index` rather than a `pad`
+            other = other.copy()
             other['index'] = other.pop('pad')
         # use parent's comparison method
         return self.parent.isSameDevice(other)
@@ -509,6 +511,7 @@ class BaseXidVoiceKeyGroup(BaseVoiceKeyGroup):
             other = other.parent
         elif isinstance(other, dict) and "pad" in other:
             # if given a dict, make sure we have an `index` rather than a `pad`
+            other = other.copy()
             other['index'] = other.pop('pad')
         # use parent's comparison method
         return self.parent.isSameDevice(other)

--- a/psychopy_cedrus/base.py
+++ b/psychopy_cedrus/base.py
@@ -207,6 +207,11 @@ class BaseXidDevice(BaseDevice):
                     # these we need to distinguish from keys
                     if resp['key'] not in node.keys:
                         continue
+                # if device refers to a node by selector, send to that node
+                if isinstance(resp['port'], bytes):
+                    if resp['port'].decode() in self.selectors:
+                        if resp['port'].decode() not in node.selectors:
+                            continue
                 # dispatch to node
                 message = node.parseMessage(resp)
                 node.receiveMessage(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ urls.homepage = "https://psychopy.github.io/psychopy-cedrus"
 urls.changelog = "https://github.com/psychopy/psychopy-cedrus/blob/main/CHANGELOG.txt"
 
 dependencies = [
-  "pyxid2>=1.0.8"
+  "pyxid2==1.0.8"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Problem was that `isSameDevice` altered the live object it was given, so when `getDeviceProfile` compares each available device's dict, in the process the dict get an erroneous "index" key added. Solution is to compare to a copy of the dict rather than the dict object itself.